### PR TITLE
Add statistical matching to the results

### DIFF
--- a/poster.tex
+++ b/poster.tex
@@ -168,7 +168,7 @@ in the Healthy Brain Network dataset
 
 \begin{minipage}[b]{0.5\textwidth}
     \begin{center}
-        No differences found between ELA groups (p>0.05, FDR corrected for multiple comparisons)
+        No differences found between statistically matched ELA groups (p>0.05, FDR corrected for multiple comparisons)
     \end{center}
 
     \vspace{-1em}


### PR DESCRIPTION
To clarify which groups are being compared. I think we need additional clarification here, if the comparison is just between the "high" and "low" ELA groups.